### PR TITLE
Update TextareaField.ss

### DIFF
--- a/templates/SilverStripe/Forms/TextareaField.ss
+++ b/templates/SilverStripe/Forms/TextareaField.ss
@@ -1,1 +1,1 @@
-<textarea class="$Silverstrap.control $extraClass" $getAttributesHTML('class')<% if $isReadonly %> readonly<% else_if $isDisabled %> disabled<% end_if %>>$Value</textarea>
+<textarea class="$Silverstrap.control $extraClass" $getAttributesHTML('class')<% if $isReadonly %> readonly<% else_if $isDisabled %> disabled<% end_if %>>$ValueEntities.RAW</textarea>


### PR DESCRIPTION
When using $Value, it will always add `<br />` into the textarea. This should be avoided. Using $ValueEntities.RAW instead.